### PR TITLE
Add DB Read Helper Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "watch": "concurrently \"webpack --watch\" \"webpack --config webpack.config.js --watch\"",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "read:db:csv": "cd server && npm run read:db:csv",
+    "read:db:json": "cd server && npm run read:db:json"
   },
   "repository": {
     "type": "git",

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env*
+output

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,9 @@
         "winston": "^3.17.0",
         "zod": "^3.24.4",
         "zod-express-middleware": "^1.4.0"
+      },
+      "devDependencies": {
+        "cross-env": "^10.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -51,6 +54,13 @@
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -1220,6 +1230,39 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1836,6 +1879,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -2046,6 +2096,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -2243,6 +2303,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2464,6 +2547,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/winston": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,9 @@
     "start:debug": "tsx --inspect-brk ./src/index.ts",
     "migrate": "tsx scripts/db/migrate.ts",
     "generate:migrations": "npx drizzle-kit generate",
-    "generate:migrations:custom": "npx drizzle-kit generate --custom"
+    "generate:migrations:custom": "npx drizzle-kit generate --custom",
+    "read:db:csv": "cross-env OUTPUT_FORMAT=csv tsx scripts/db/read.ts",
+    "read:db:json": "cross-env OUTPUT_FORMAT=json tsx scripts/db/read.ts"
   },
   "dependencies": {
     "@types/cors": "^2.8.19",
@@ -29,5 +31,8 @@
   },
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "cross-env": "^10.0.0"
+  }
 }

--- a/server/scripts/db/read.ts
+++ b/server/scripts/db/read.ts
@@ -1,0 +1,163 @@
+// Load environment variables
+import "../../src/config";
+import { logger } from "../../src/logger";
+import { databaseClient } from "../../src/db";
+import { gameStatsTable } from "../../src/db/schema";
+import fs from "fs";
+import path from "path";
+
+const outputFile = "./output/game-stats";
+
+const ensureOutputDir = () => {
+  const outputDir = path.dirname(outputFile);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+};
+
+const readFromDatabase = async () => {
+  logger.info("Reading game stats from database...");
+  const results = await databaseClient.select().from(gameStatsTable);
+  logger.info(`Read ${results.length} game stat entries from database`);
+  return results;
+};
+
+const readAsJson = async () => {
+  try {
+    const results = await readFromDatabase();
+    ensureOutputDir();
+
+    fs.writeFileSync(outputFile + ".json", JSON.stringify(results, null, 2));
+    logger.info(`JSON exported to ${outputFile}.json`);
+    process.exit(0);
+  } catch (error) {
+    logger.error("Error reading game stats from database:", error);
+    process.exit(1);
+  }
+};
+
+const convertValue = (value: any): string => {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return "null";
+  }
+
+  if (typeof value === "object" && Array.isArray(value)) {
+    return value.map(convertValue).join(";");
+  }
+
+  return String(value);
+};
+
+// Helper functions for special field formatting
+const formatEnemiesKilled = (enemiesKilled: any): string => {
+  if (!Array.isArray(enemiesKilled)) return "null";
+  return enemiesKilled.map(String).join(";");
+};
+
+const formatSidePathsEntered = (sidePathsEntered: any): string => {
+  if (!Array.isArray(sidePathsEntered)) {
+    logger.info(
+      `sidePathsEntered is not an array: ${JSON.stringify(sidePathsEntered)}`,
+    );
+    return "null";
+  }
+  if (sidePathsEntered.length === 0) {
+    return "null";
+  }
+  return sidePathsEntered
+    .map((path: any) => `(${path.sidePath};${path.depth})`)
+    .join(";");
+};
+
+const formatDeviceType = (deviceType: any): string => {
+  if (!deviceType || typeof deviceType !== "object") return "null";
+
+  const parts: string[] = [];
+  if (deviceType.device?.type) parts.push(deviceType.device.type);
+  if (deviceType.browser?.name) parts.push(deviceType.browser.name);
+  if (deviceType.os?.name) parts.push(deviceType.os.name);
+
+  return parts.length > 0 ? parts.join(";") : "null";
+};
+
+const formatInventory = (inventory: any): string => {
+  if (!Array.isArray(inventory)) return "null";
+  return inventory
+    .map((item: any) => `(${item.name};${item.stackSize})`)
+    .join(";");
+};
+
+const formatField = (key: string, value: any): string => {
+  switch (key) {
+    case "enemiesKilled":
+      return formatEnemiesKilled(value);
+    case "sidePathsEntered":
+      return formatSidePathsEntered(value);
+    case "deviceType":
+      return formatDeviceType(value);
+    case "inventory":
+      return formatInventory(value);
+    default:
+      return convertValue(value);
+  }
+};
+
+const readAsCsv = async () => {
+  try {
+    const results = await readFromDatabase();
+    ensureOutputDir();
+
+    const transformedResults = results.map((result) => {
+      const { gameState, ...rest } = result;
+
+      const formatted: Record<string, any> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        formatted[key] = formatField(key, value);
+      }
+
+      return formatted;
+    });
+
+    const headers = Object.keys(transformedResults[0]);
+
+    const csvContent = [
+      headers.join(","),
+      ...transformedResults.map((row) =>
+        headers
+          .map((header) => {
+            const value = row[header];
+            if (
+              typeof value === "string" &&
+              (value.includes(",") || value.includes('"'))
+            ) {
+              return `"${value.replace(/"/g, '""')}"`;
+            }
+            return value;
+          })
+          .join(","),
+      ),
+    ].join("\n");
+
+    fs.writeFileSync(outputFile + ".csv", csvContent);
+    logger.info(`CSV exported to ${outputFile}.csv`);
+    process.exit(0);
+  } catch (error) {
+    logger.error("Error reading game stats from database:", error);
+    process.exit(1);
+  }
+};
+
+const outputFormat = process.env.OUTPUT_FORMAT || "json";
+
+if (outputFormat === "json") {
+  readAsJson();
+} else if (outputFormat === "csv") {
+  readAsCsv();
+} else {
+  logger.error("Invalid output format:", outputFormat);
+  process.exit(1);
+}

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,15 +1,21 @@
 import { config as configure } from "dotenv";
-import { getEnvironmentVariableOrThrow } from "./utils";
+import {
+  getEnvironmentVariableOrDefault,
+  getEnvironmentVariableOrThrow,
+} from "./utils";
 
-configure({ path: `.env.${process.env.NODE_ENV ?? "development"}` });
+const NODE_ENV = getEnvironmentVariableOrDefault("NODE_ENV", "development");
 
-const NODE_ENV = getEnvironmentVariableOrThrow("NODE_ENV");
+configure({
+  path: `.env.${NODE_ENV}`,
+});
+
 const isDevelopment = NODE_ENV.startsWith("dev");
 
 export const config = {
   isDevelopment,
   server: {
-    port: getEnvironmentVariableOrThrow("PORT"),
+    port: getEnvironmentVariableOrDefault("PORT", "3000"),
   },
   database: {
     url: getEnvironmentVariableOrThrow("DATABASE_URL"),

--- a/server/src/config/utils.ts
+++ b/server/src/config/utils.ts
@@ -7,3 +7,14 @@ export const getEnvironmentVariableOrThrow = (name: string): string => {
   }
   return value;
 };
+
+export const getEnvironmentVariableOrDefault = (
+  name: string,
+  defaultValue: string,
+): string => {
+  const value = process.env[name];
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return value;
+};


### PR DESCRIPTION
Steps to use DB scripts:
1. Create a `.env.development` file (that exact name) at `server/.env.development.`. Give it the following content:
```
DATABASE_URL=<value>
```
2. While in the top-level project directory, run either:
```
npm run read:db:csv
// OR
npm run read:db:json
```
3. These read all data from the DB and write it locally under `server/output/game-stats.json` and `server/output/game-stats.csv` respectively.

Note: these commands will not work without the `.env.development` file. Also, `gameState` is omitted from the CSV output and only some of the `deviceType` info is included in the CSV. _All data_ is written to the JSON output (but the format is inherently harder to read).