### PR TITLE
Update IP Parsing to Use `request-ip` NPM Package

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,12 +20,14 @@
         "http-status-codes": "^2.3.0",
         "morgan": "^1.10.1",
         "postgres": "^3.4.5",
+        "request-ip": "^3.3.0",
         "tsx": "^4.20.4",
         "winston": "^3.17.0",
         "zod": "^3.24.4",
         "zod-express-middleware": "^1.4.0"
       },
       "devDependencies": {
+        "@types/request-ip": "^0.0.41",
         "cross-env": "^10.0.0"
       }
     },
@@ -982,6 +984,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/request-ip": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/request-ip/-/request-ip-0.0.41.tgz",
+      "integrity": "sha512-Qzz0PM2nSZej4lsLzzNfADIORZhhxO7PED0fXpg4FjXiHuJ/lMyUg+YFF5q8x9HPZH3Gl6N+NOM8QZjItNgGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
@@ -2190,6 +2202,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "http-status-codes": "^2.3.0",
     "morgan": "^1.10.1",
     "postgres": "^3.4.5",
+    "request-ip": "^3.3.0",
     "tsx": "^4.20.4",
     "winston": "^3.17.0",
     "zod": "^3.24.4",
@@ -33,6 +34,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
+    "@types/request-ip": "^0.0.41",
     "cross-env": "^10.0.0"
   }
 }

--- a/server/src/http/routes/game.ts
+++ b/server/src/http/routes/game.ts
@@ -10,6 +10,7 @@ import express from "express";
 import { logger } from "../../logger";
 import { gameStatsDal } from "db/dal/game-stats";
 import HttpStatus from "http-status-codes";
+import { getClientIp } from "request-ip";
 
 const recordGameStats = async (
   req: Request<{}, {}, GameStats>,
@@ -19,7 +20,7 @@ const recordGameStats = async (
   logger.info("Recording game stats:", gameStats);
   await gameStatsDal.createGameStats({
     ...gameStats,
-    ipAddress: req.ip ?? null,
+    ipAddress: getClientIp(req),
   });
   return res
     .status(HttpStatus.CREATED)


### PR DESCRIPTION
## Description
This PR updates our BE IP parsing (used for game session tracking) to use the `request-ip` NPM package, which has better IP parsing behavior than the Express `req.ip`.